### PR TITLE
:bug: Serial connection stays active for deleted barrels.

### DIFF
--- a/src/nl/wouterdebruijn/EasyH2O/Dashboard.java
+++ b/src/nl/wouterdebruijn/EasyH2O/Dashboard.java
@@ -105,6 +105,9 @@ public class Dashboard extends JFrame {
                     preparedStatement.executeUpdate();
                     selectedRainbarrel = 0;
 
+                    // Disconnect from deleted rainbarrel
+                    regenton.disconnect();
+
                     // Update main array;
                     Main.initRegentonnen();
 


### PR DESCRIPTION
Fixes "Deleting rain barrel doesn't close serial port" of #14 